### PR TITLE
V0.7.5

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -20,7 +20,7 @@ spawnTableDefault: 2
 
 # This is the en_US.yml version for reference.
 # ONLY EDIT ONCE THE LANGUAGE FILE HAS BEEN UPDATED.
-languageFile: 2
+languageFile: 3
 
 # This sets the language file for which plugin notification texts will pull from.
 locale: en_US

--- a/src/languages/en_US.yml
+++ b/src/languages/en_US.yml
@@ -5,7 +5,7 @@ carePackage: Care package delivered!
 chestplate: Chestplate equipped!
 closeError: Arena is closed.
 commandError: Invalid command. Use /vd help for more info.
-cooldownError: You have %.1f seconds left on your cooldown!
+cooldownError: You have &b%.1f &cseconds left on your cooldown!
 crystals: You earned &b%d crystals &6this game!
 customShopError: Custom shop has been disabled!
 death: has died and will respawn next round.

--- a/src/me/theguyhere/villagerdefense/GUI/InventoryEvents.java
+++ b/src/me/theguyhere/villagerdefense/GUI/InventoryEvents.java
@@ -103,6 +103,10 @@ public class InventoryEvents implements Listener {
 		// Cancel the event
 		e.setCancelled(true);
 
+		// Ignore clicks in player inventory
+		if (e.getClickedInventory().getType() == InventoryType.PLAYER)
+			return;
+
 		ItemStack button = e.getCurrentItem();
 
 		// Get material and name of button

--- a/src/me/theguyhere/villagerdefense/GUI/InventoryEvents.java
+++ b/src/me/theguyhere/villagerdefense/GUI/InventoryEvents.java
@@ -100,10 +100,6 @@ public class InventoryEvents implements Listener {
 		if (e.getClickedInventory() == null)
 			return;
 
-		// Ignore clicks in player inventory
-		if (e.getClickedInventory().getType() == InventoryType.PLAYER)
-			return;
-
 		// Cancel the event
 		e.setCancelled(true);
 
@@ -781,7 +777,6 @@ public class InventoryEvents implements Listener {
 		// Confirmation menus
 		else if (title.contains("Remove")) {
 			InventoryMeta meta = (InventoryMeta) e.getInventory().getHolder();
-			Arena arenaInstance = game.arenas.get(meta.getInteger1());
 
 			// Confirm to remove portal
 			if (title.contains("Remove Portal?")) {
@@ -791,6 +786,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove the portal, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					// Remove portal data, close arena
 					arenaInstance.setPortal(null);
 					arenaInstance.setClosed(true);
@@ -812,6 +809,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove the leaderboard, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					// Remove leaderboard data, close arena
 					arenaInstance.setArenaBoard(null);
 
@@ -832,6 +831,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove spawn, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					arenaInstance.setPlayerSpawn(null);
 					arenaInstance.setClosed(true);
 					player.sendMessage(Utils.notify("&aSpawn removed!"));
@@ -848,6 +849,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove spawn, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					arenaInstance.setWaitingRoom(null);
 					player.sendMessage(Utils.notify("&aWaiting room removed!"));
 					player.openInventory(inv.createWaitingRoomInventory(meta.getInteger1()));
@@ -862,6 +865,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove the monster spawn, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					arenaInstance.setMonsterSpawn(meta.getInteger2(), null);
 					if (arenaInstance.getMonsterSpawns().stream().noneMatch(Objects::nonNull))
 						arenaInstance.setClosed(true);
@@ -879,6 +884,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove the villager spawn, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					arenaInstance.setVillagerSpawn(meta.getInteger2(), null);
 					if (arenaInstance.getVillagerSpawns().stream().noneMatch(Objects::nonNull))
 						arenaInstance.setClosed(true);
@@ -1050,6 +1057,8 @@ public class InventoryEvents implements Listener {
 
 				// Remove arena data, then return to previous menu
 				else if (buttonName.contains("YES")) {
+					Arena arenaInstance = game.arenas.get(meta.getInteger1());
+
 					// Remove data
 					arenaInstance.remove();
 					game.arenas.set(meta.getInteger1(), null);

--- a/src/me/theguyhere/villagerdefense/Main.java
+++ b/src/me/theguyhere/villagerdefense/Main.java
@@ -90,7 +90,7 @@ public class Main extends JavaPlugin {
 		int arenaDataVersion = 3;
 		int playerDataVersion = 1;
 		int spawnTableVersion = 1;
-		int languageFileVersion = 2;
+		int languageFileVersion = 3;
 		int defaultSpawnVersion = 2;
 
 		// Check config version

--- a/src/me/theguyhere/villagerdefense/game/listeners/AbilityEvents.java
+++ b/src/me/theguyhere/villagerdefense/game/listeners/AbilityEvents.java
@@ -8,6 +8,7 @@ import me.theguyhere.villagerdefense.game.models.VDPlayer;
 import me.theguyhere.villagerdefense.tools.Utils;
 import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Material;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.*;
@@ -47,6 +48,20 @@ public class AbilityEvents implements Listener {
             return;
 
         Player player = e.getPlayer();
+
+        // Avoid accidental usage when holding food, shop, or potions
+        if (player.getInventory().getItemInMainHand().getType() == Material.EMERALD ||
+                player.getInventory().getItemInMainHand().getType() == Material.BEETROOT ||
+                player.getInventory().getItemInMainHand().getType() == Material.CARROT ||
+                player.getInventory().getItemInMainHand().getType() == Material.BREAD ||
+                player.getInventory().getItemInMainHand().getType() == Material.MUTTON ||
+                player.getInventory().getItemInMainHand().getType() == Material.COOKED_BEEF ||
+                player.getInventory().getItemInMainHand().getType() == Material.GOLDEN_CARROT ||
+                player.getInventory().getItemInMainHand().getType() == Material.GOLDEN_APPLE ||
+                player.getInventory().getItemInMainHand().getType() == Material.ENCHANTED_GOLDEN_APPLE ||
+                player.getInventory().getItemInMainHand().getType() == Material.GLASS_BOTTLE
+        )
+            return;
 
         // See if the player is in a game
         if (game.arenas.stream().filter(Objects::nonNull).noneMatch(a -> a.hasPlayer(player)))

--- a/src/me/theguyhere/villagerdefense/game/listeners/AbilityEvents.java
+++ b/src/me/theguyhere/villagerdefense/game/listeners/AbilityEvents.java
@@ -6,6 +6,8 @@ import me.theguyhere.villagerdefense.game.models.Game;
 import me.theguyhere.villagerdefense.game.models.Kits;
 import me.theguyhere.villagerdefense.game.models.VDPlayer;
 import me.theguyhere.villagerdefense.tools.Utils;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.*;
@@ -72,7 +74,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -87,8 +90,8 @@ public class AbilityEvents implements Listener {
                 fireball.setYield(yield);
                 fireball.setShooter(player);
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Ninja
@@ -104,7 +107,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -119,8 +123,8 @@ public class AbilityEvents implements Listener {
                 Utils.getPets(player).forEach(wolf ->
                         wolf.addPotionEffect((new PotionEffect(PotionEffectType.INVISIBILITY, duration, 0))));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Templar
@@ -136,7 +140,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -167,8 +172,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.ABSORPTION, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Warrior
@@ -184,7 +189,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -215,8 +221,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.INCREASE_DAMAGE, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.INCREASE_DAMAGE, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Knight
@@ -232,7 +238,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -263,8 +270,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Priest
@@ -280,7 +287,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -311,8 +319,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.REGENERATION, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Siren
@@ -328,7 +336,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -362,8 +371,8 @@ public class AbilityEvents implements Listener {
                     Utils.getNearbyMonsters(player, range).forEach(ent -> ent.addPotionEffect(
                             new PotionEffect(PotionEffectType.WEAKNESS, altDuration, amp2)));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Monk
@@ -379,7 +388,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -410,8 +420,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.FAST_DIGGING, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.FAST_DIGGING, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
 
         // Messenger
@@ -427,7 +437,8 @@ public class AbilityEvents implements Listener {
 
             // Check for zero level
             if (level == 0) {
-                player.sendMessage(Utils.notify("&c" + language.getString("levelError")));
+                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format("&c" + language.getString("levelError"))));
                 return;
             }
 
@@ -458,8 +469,8 @@ public class AbilityEvents implements Listener {
                         new PotionEffect(PotionEffectType.SPEED, altDuration, amplifier)));
                 player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, duration, amplifier));
                 cooldowns.put(gamer, System.currentTimeMillis() + coolDown);
-            } else player.sendMessage(Utils.notify(
-                    String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif))));
+            } else player.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(
+				Utils.format(String.format("&c" + language.getString("cooldownError"), Utils.millisToSeconds(dif)))));
         }
     }
 

--- a/src/me/theguyhere/villagerdefense/game/listeners/GameEvents.java
+++ b/src/me/theguyhere/villagerdefense/game/listeners/GameEvents.java
@@ -513,7 +513,7 @@ public class GameEvents implements Listener {
 				gamer.getPlayer().sendMessage(Utils.notify("&b" + player.getName() + "&c " +
 						plugin.getLanguageData().getString("death")));
 				if (arena.hasPlayerDeathSound())
-					gamer.getPlayer().playSound(player.getLocation(), Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 4, .75f);
+					gamer.getPlayer().playSound(player.getLocation(), Sound.ENTITY_LIGHTNING_BOLT_THUNDER, 10, .75f);
 		});
 
 		// Update scoreboards

--- a/src/me/theguyhere/villagerdefense/game/models/Arena.java
+++ b/src/me/theguyhere/villagerdefense/game/models/Arena.java
@@ -210,7 +210,7 @@ public class Arena {
     }
 
     public Location getPortal() {
-        return Utils.getConfigLocationNoRotation(plugin, "portal." + arena);
+        return Utils.getConfigLocationNoPitch(plugin, "portal." + arena);
     }
 
     public void setPortal(Location location) {
@@ -236,7 +236,7 @@ public class Arena {
     }
 
     public Location getPlayerSpawn() {
-        return Utils.getConfigLocationNoRotation(plugin, path + ".spawn");
+        return Utils.getConfigLocation(plugin, path + ".spawn");
     }
 
     public void setPlayerSpawn(Location location) {

--- a/src/me/theguyhere/villagerdefense/game/models/GameItems.java
+++ b/src/me/theguyhere/villagerdefense/game/models/GameItems.java
@@ -160,38 +160,12 @@ public class GameItems {
 					price += 75;
 				}
 				break;
-			case 6:
-				if (chance < .25) {
-					enchantments.put(Enchantment.DURABILITY, 2);
-					price += 50;
-				} else if (chance < .9) {
-					enchantments.put(Enchantment.DURABILITY, 3);
-					price += 75;
-				}
-				break;
-			case 7:
+			default:
 				if (chance < .6) {
 					enchantments.put(Enchantment.DURABILITY, 3);
 					price += 75;
 				}
 				break;
-			case 8:
-				if (chance < .75) {
-					enchantments.put(Enchantment.DURABILITY, 3);
-					price += 75;
-				} else if (chance < .8) {
-					enchantments.put(Enchantment.DURABILITY, 4);
-					price += 100;
-				}
-				break;
-			default:
-				if (chance < .8) {
-					enchantments.put(Enchantment.DURABILITY, 3);
-					price += 75;
-				} else {
-					enchantments.put(Enchantment.DURABILITY, 4);
-					price += 100;
-				}
 		}
 		chance = r.nextDouble();
 
@@ -327,7 +301,7 @@ public class GameItems {
 					price += 200;
 				}
 				break;
-			case 7:
+			default:
 				if (chance < .05) {
 					enchantments.put(Enchantment.SWEEPING_EDGE, 2);
 					price += 100;
@@ -339,14 +313,6 @@ public class GameItems {
 					price += 200;
 				}
 				break;
-			default:
-				if (chance < .4) {
-					enchantments.put(Enchantment.SWEEPING_EDGE, 3);
-					price += 150;
-				} else if (chance < .6) {
-					enchantments.put(Enchantment.SWEEPING_EDGE, 4);
-					price += 200;
-				}
 		}
 		chance = r.nextDouble();
 

--- a/src/me/theguyhere/villagerdefense/game/models/GameItems.java
+++ b/src/me/theguyhere/villagerdefense/game/models/GameItems.java
@@ -2354,9 +2354,6 @@ public class GameItems {
 	public static @NotNull ItemStack arrows() {
 		return Utils.createItems(Material.ARROW, 16, null, Utils.format("&2Gems: &a45"));
 	}
-	public static @NotNull ItemStack arrowsSpectral() {
-		return Utils.createItems(Material.SPECTRAL_ARROW, 8, null, Utils.format("&2Gems: &a30"));
-	}
 	public static @NotNull ItemStack arrowsS() {
 		return Utils.createPotionItems(Material.TIPPED_ARROW, new PotionData(PotionType.SLOWNESS), 8,
 				null, Utils.format("&2Gems: &a50"));
@@ -5034,7 +5031,7 @@ public class GameItems {
 		return Utils.createItem(Material.GOLDEN_CARROT, null, Utils.format("&2Gems: &a80"));
 	}
 	public static @NotNull ItemStack steak() {
-		return Utils.createItem(Material.COOKED_BEEF, null, Utils.format("&2Gems: &a50"));
+		return Utils.createItems(Material.COOKED_BEEF, 2, null, Utils.format("&2Gems: &a60"));
 	}
 	public static @NotNull ItemStack mutton() {
 		return Utils.createItems(Material.COOKED_MUTTON, 2, null, Utils.format("&2Gems: &a40"));
@@ -5146,10 +5143,8 @@ public class GameItems {
 					return shield(level);
 				else if (chance < .9)
 					return bow(level);
-				else if (chance < .94)
+				else if (chance < .96)
 					return arrows();
-				else if (chance < .97)
-					return arrowsSpectral();
 				else return arrowsP();
 			case 3:
 				if (chance < .3)
@@ -5162,10 +5157,8 @@ public class GameItems {
 					return shield(level);
 				else if (chance < .9)
 					return crossbow(level);
-				else if (chance < .92)
+				else if (chance < .93)
 					return arrows();
-				else if (chance < .94)
-					return arrowsSpectral();
 				else if (chance < .96)
 					return arrowsP();
 				else if (chance < .98)
@@ -5184,10 +5177,8 @@ public class GameItems {
 					return shield(level);
 				else if (chance < .85)
 					return crossbow(level);
-				else if (chance < .88)
+				else if (chance < .9)
 					return arrows();
-				else if (chance < .91)
-					return arrowsSpectral();
 				else if (chance < .93)
 					return arrowsPPlus();
 				else if (chance < .95)
@@ -5210,10 +5201,8 @@ public class GameItems {
 					return crossbow(level);
 				else if (chance < .8)
 					return trident(level);
-				else if (chance < .83)
+				else if (chance < .85)
 					return arrows();
-				else if (chance < .86)
-					return arrowsSpectral();
 				else if (chance < .89)
 					return arrowsPPlus();
 				else if (chance < .92)
@@ -5238,10 +5227,8 @@ public class GameItems {
 					return crossbow(level);
 				else if (chance < .8)
 					return trident(level);
-				else if (chance < .83)
+				else if (chance < .85)
 					return arrows();
-				else if (chance < .86)
-					return arrowsSpectral();
 				else if (chance < .89)
 					return arrowsPPlus();
 				else if (chance < .92)
@@ -5296,16 +5283,12 @@ public class GameItems {
 			case 1:
 				return arrows();
 			case 2:
-				if (chance < .4)
+				if (chance < .6)
 					return arrows();
-				else if (chance < .7)
-					return arrowsSpectral();
 				else return arrowsP();
 			case 3:
-				if (chance < .2)
+				if (chance < .3)
 					return arrows();
-				else if (chance < .4)
-					return arrowsSpectral();
 				else if (chance < .6)
 					return arrowsP();
 				else if (chance < .8)
@@ -5314,10 +5297,8 @@ public class GameItems {
 					return arrowsW();
 				else return arrowsD();
 			case 4:
-				if (chance < .2)
+				if (chance < .35)
 					return arrows();
-				else if (chance < .4)
-					return arrowsSpectral();
 				else if (chance < .55)
 					return arrowsPPlus();
 				else if (chance < .7)
@@ -5328,10 +5309,8 @@ public class GameItems {
 					return arrowsD();
 				else return rockets();
 			default:
-				if (chance < .15)
+				if (chance < .25)
 					return arrows();
-				else if (chance < .3)
-					return arrowsSpectral();
 				else if (chance < .5)
 					return arrowsPPlus();
 				else if (chance < .7)

--- a/src/me/theguyhere/villagerdefense/game/models/Tasks.java
+++ b/src/me/theguyhere/villagerdefense/game/models/Tasks.java
@@ -361,7 +361,7 @@ public class Tasks {
 											Utils.secondsToTicks(.5), Utils.secondsToTicks(1.5),
 											Utils.secondsToTicks(.5)));
 
-							// Set monsters glowing
+							// Set monsters glowing when time is low
 							arenaInstance.getPlayerSpawn().getWorld().getNearbyEntities(arenaInstance.getPlayerSpawn(),
 									200, 200, 200).stream().filter(entity -> entity.hasMetadata("VD"))
 									.filter(entity -> entity instanceof Monster || entity instanceof Slime ||

--- a/src/me/theguyhere/villagerdefense/tools/Utils.java
+++ b/src/me/theguyhere/villagerdefense/tools/Utils.java
@@ -368,9 +368,9 @@ public class Utils {
                 if (ent.hasMetadata("VD")) ent.remove();
         });
 
-        // Clear the arena for items
+        // Clear the arena for items and experience orbs
         ents.forEach(ent -> {
-            if (ent instanceof Item) ent.remove();
+            if (ent instanceof Item || ent instanceof ExperienceOrb) ent.remove();
         });
     }
 

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,6 @@
 main: me.theguyhere.villagerdefense.Main
 name: VillagerDefense
-version: 0.7.4
+version: 0.7.5
 author: Theguyhere
 api-version: 1.16
 depend: [HolographicDisplays]


### PR DESCRIPTION
- Made player death sound louder
- Fixed issue where portal NPCs were not rotating
- Player spawns now allow for setting player pitch and yaw when spawning
- Fixed issue where shift-clicking item into custom inventories was possible, resulting in loss of item
- Fixed issue where deleting leaderboards or lobby was broken
- Simplified certain game item enchant generation
- Moved cooldown messages and gem pickup messages to action bar chat
- Fixed arena clearing not accounting for experience orbs
- Glowing now takes place when there are 20% of monsters remaining
- Cooldown time is now a different color from the rest of the warning
- Removed spectral arrows from shop
- Ability no longer triggers when holding shop, food, or glass bottle in main hand to prevent accidental triggers