### PR TITLE
Waiting music upgrade

### DIFF
--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/GUI/Inventories.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/GUI/Inventories.java
@@ -10,6 +10,7 @@ import me.theguyhere.villagerdefense.plugin.game.models.players.VDPlayer;
 import me.theguyhere.villagerdefense.common.CommunicationManager;
 import me.theguyhere.villagerdefense.plugin.tools.DataManager;
 import me.theguyhere.villagerdefense.plugin.tools.ItemManager;
+import me.theguyhere.villagerdefense.plugin.tools.NMSVersion;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -1751,6 +1752,8 @@ public class Inventories {
 		inv.setItem(3, arenaInstance.getWaitingSoundButton(3));
 		inv.setItem(4, arenaInstance.getWaitingSoundButton(4));
 		inv.setItem(5, arenaInstance.getWaitingSoundButton(5));
+		if (NMSVersion.isGreaterEqualThan(NMSVersion.v1_18_R1))
+			inv.setItem(8, arenaInstance.getWaitingSoundButton(8));
 
 		inv.setItem(9, arenaInstance.getWaitingSoundButton(9));
 		inv.setItem(10, arenaInstance.getWaitingSoundButton(10));

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/GUI/Inventories.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/GUI/Inventories.java
@@ -1699,7 +1699,7 @@ public class Inventories {
 
 		// Option to edit waiting music
 		inv.setItem(4, ItemManager.createItem(Material.MUSIC_DISC_MELLOHI,
-				CommunicationManager.format("&6&lWaiting Sound"),
+				CommunicationManager.format("&6&lWaiting Sound: &b&l" + arenaInstance.getWaitingSoundName()),
 				ItemManager.BUTTON_FLAGS,
 				null,
 				CommunicationManager.format("&7Played while players wait"),

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/Main.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/Main.java
@@ -42,9 +42,9 @@ public class Main extends JavaPlugin {
 
 	// Global state variables
 	private static boolean outdated = false; // DO NOT CHANGE
-	public static final boolean releaseMode = true;
+	public static final boolean releaseMode = false;
 	public static final int configVersion = 7;
-	public static final int arenaDataVersion = 4;
+	public static final int arenaDataVersion = 5;
 	public static final int playerDataVersion = 1;
 	public static final int spawnTableVersion = 1;
 	public static final int languageFileVersion = 12;

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/commands/Commands.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/commands/Commands.java
@@ -700,14 +700,76 @@ public class Commands implements CommandExecutor {
 									plugin.getLanguageStringFormatted("messages.manualUpdateWarn", 
 											"arenaData.yml"), 0);
 						}
-					} else if (arenaDataVersion < Main.arenaDataVersion) {
-						if (player != null)
-							PlayerManager.notifyAlert(player, 
-									plugin.getLanguageString("messages.manualUpdateWarn"), ChatColor.AQUA,
-									"arenaData.yml");
-						else CommunicationManager.debugError(
-								plugin.getLanguageStringFormatted("messages.manualUpdateWarn",
-										"arenaData.yml"), 0);
+					} else if (arenaDataVersion < 5) {
+						try {
+							// Translate waiting sounds
+							Objects.requireNonNull(arenaData.getConfigurationSection("")).getKeys(false)
+									.forEach(key -> {
+										String path = key + ".sounds.waiting";
+										if (key.charAt(0) == 'a' && key.length() < 4 && arenaData.contains(path)) {
+											int oldValue = arenaData.getInt(path);
+											switch (oldValue) {
+												case 0:
+													arenaData.set(path, "cat");
+													break;
+												case 1:
+													arenaData.set(path, "blocks");
+													break;
+												case 2:
+													arenaData.set(path, "far");
+													break;
+												case 3:
+													arenaData.set(path, "strad");
+													break;
+												case 4:
+													arenaData.set(path, "mellohi");
+													break;
+												case 5:
+													arenaData.set(path, "ward");
+													break;
+												case 9:
+													arenaData.set(path, "chirp");
+													break;
+												case 10:
+													arenaData.set(path, "stal");
+													break;
+												case 11:
+													arenaData.set(path, "mall");
+													break;
+												case 12:
+													arenaData.set(path, "wait");
+													break;
+												case 13:
+													arenaData.set(path, "pigstep");
+													break;
+												default:
+													arenaData.set(path, "none");
+											}
+										}
+									});
+							plugin.saveArenaData();
+
+							// Flip flag and update config.yml
+							fixed = true;
+							plugin.getConfig().set("arenaData", 5);
+							plugin.saveConfig();
+
+							// Notify
+							if (player != null)
+								PlayerManager.notifySuccess(player,
+										plugin.getLanguageString("confirms.autoUpdate"), ChatColor.AQUA,
+										"arenaData.yml", "5");
+							CommunicationManager.debugInfo(plugin.getLanguageStringFormatted(
+									"confirms.autoUpdate", "arenaData.yml", "5"), 0);
+						} catch (Exception e) {
+							if (player != null)
+								PlayerManager.notifyAlert(player,
+										plugin.getLanguageString("messages.manualUpdateWarn"), ChatColor.AQUA,
+										"arenaData.yml");
+							else CommunicationManager.debugError(
+									plugin.getLanguageStringFormatted("messages.manualUpdateWarn",
+											"arenaData.yml"), 0);
+						}
 					}
 
 					// Check if playerData.yml is outdated

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/GameManager.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/GameManager.java
@@ -9,6 +9,7 @@ import me.theguyhere.villagerdefense.plugin.game.models.arenas.Arena;
 import me.theguyhere.villagerdefense.plugin.game.models.players.VDPlayer;
 import me.theguyhere.villagerdefense.common.CommunicationManager;
 import me.theguyhere.villagerdefense.plugin.tools.DataManager;
+import me.theguyhere.villagerdefense.plugin.tools.NMSVersion;
 import me.theguyhere.villagerdefense.plugin.tools.WorldManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -25,10 +26,15 @@ public class GameManager {
 	private static final InfoBoard[] infoBoards = new InfoBoard[8];
 	private static final Map<String, Leaderboard> leaderboards = new HashMap<>();
 	private static Location lobby;
+	private static final List<String> validSounds = new LinkedList<>(Arrays.asList("blocks", "cat", "chirp", "far",
+			"mall", "mellohi", "pigstep", "stal", "strad", "wait", "ward"));
 
 	public GameManager(Main plugin) {
 		GameManager.plugin = plugin;
 		ConfigurationSection section;
+
+		if (NMSVersion.isGreaterEqualThan(NMSVersion.v1_18_R1))
+			validSounds.add("otherside");
 
 		section = plugin.getArenaData().getConfigurationSection("");
 		if (section != null)
@@ -100,6 +106,10 @@ public class GameManager {
 
 	public static Arena[] getArenas() {
 		return arenas;
+	}
+
+	public static List<String> getValidSounds() {
+		return validSounds;
 	}
 
 	/**

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -2644,7 +2644,7 @@ public class InventoryListener implements Listener {
 					return;
 				}
 
-				arenaInstance.setWaitingSound(slot);
+				arenaInstance.setWaitingSound(buttonName.toLowerCase());
 				player.openInventory(Inventories.createWaitSoundInventory(meta.getInteger1()));
 			}
 		}

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -2644,7 +2644,7 @@ public class InventoryListener implements Listener {
 					return;
 				}
 
-				arenaInstance.setWaitingSound(buttonName.toLowerCase());
+				arenaInstance.setWaitingSound(buttonName.toLowerCase().substring(4));
 				player.openInventory(Inventories.createWaitSoundInventory(meta.getInteger1()));
 			}
 		}

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -4,7 +4,7 @@ version: 7
 
 # This is the arenaData.yml structure version for reference.
 # ONLY EDIT ONCE FILE HAS BEEN UPDATED.
-arenaData: 4
+arenaData: 5
 
 # This is the playerData.yml structure version for reference.
 # ONLY EDIT ONCE FILE HAS BEEN UPDATED.


### PR DESCRIPTION
### Additions
- Added "otherside" for 1.18+

### Changes
- Changed from storing number to a string for waiting music of an arena
- Implemented an autofix through /vd fix
- Reorganized waiting music inventory alphabetically
- Waiting sound is now displayed at the sounds menu