### PR TITLE
[CHANGE] Arena relies on frequent calibration checks over event triggers

### DIFF
--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/Mobs.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/Mobs.java
@@ -39,8 +39,6 @@ public class Mobs {
             Objects.requireNonNull(livingEntity.getVehicle()).remove();
         for (Entity passenger : livingEntity.getPassengers())
             passenger.remove();
-        arena.incrementEnemies();
-        Bukkit.getPluginManager().callEvent(new ReloadBoardsEvent(arena));
 
         // Set attribute modifiers
         double difficulty = arena.getCurrentDifficulty();
@@ -80,8 +78,6 @@ public class Mobs {
         livingEntity.setMetadata("VD", new FixedMetadataValue(Main.plugin, arena.getId()));
         livingEntity.setRemoveWhenFarAway(false);
         livingEntity.setCanPickupItems(false);
-        arena.incrementEnemies();
-        Bukkit.getPluginManager().callEvent(new ReloadBoardsEvent(arena));
 
         // Set attribute modifiers
         double difficulty = arena.getCurrentDifficulty();
@@ -120,8 +116,6 @@ public class Mobs {
         livingEntity.setMetadata("VD", new FixedMetadataValue(Main.plugin, arena.getId()));
         livingEntity.setRemoveWhenFarAway(false);
         livingEntity.setCanPickupItems(false);
-        arena.incrementEnemies();
-        Bukkit.getPluginManager().callEvent(new ReloadBoardsEvent(arena));
 
         // Set attribute modifiers
         double difficulty = arena.getCurrentDifficulty();
@@ -1057,8 +1051,6 @@ public class Mobs {
         villager.setCustomName(healthBar(1, 1, 5));
         villager.setCustomNameVisible(true);
         villager.setMetadata("VD", new FixedMetadataValue(Main.plugin, arena.getId()));
-        arena.incrementVillagers();
-        Bukkit.getPluginManager().callEvent(new ReloadBoardsEvent(arena));
     }
 
     public static void setZombie(Arena arena, Zombie zombie) {

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/arenas/Arena.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/arenas/Arena.java
@@ -1492,32 +1492,12 @@ public class Arena {
         return villagers;
     }
 
-    public void incrementVillagers() {
-        villagers++;
-    }
-
-    public void decrementVillagers() {
-        if (--villagers <= 0 && status == ArenaStatus.ACTIVE && !spawningVillagers)
-            Bukkit.getScheduler().scheduleSyncDelayedTask(Main.plugin, () ->
-                    Bukkit.getPluginManager().callEvent(new GameEndEvent(this)));
-    }
-
     public void resetVillagers() {
         villagers = 0;
     }
 
     public int getEnemies() {
         return enemies;
-    }
-
-    public void incrementEnemies() {
-        enemies++;
-    }
-
-    public void decrementEnemies() {
-        if (--enemies <= 0 && status == ArenaStatus.ACTIVE && !spawningMonsters)
-            Bukkit.getScheduler().scheduleSyncDelayedTask(Main.plugin, () ->
-                    Bukkit.getPluginManager().callEvent(new WaveEndEvent(this)));
     }
 
     public void resetEnemies() {

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
@@ -329,8 +329,8 @@ public class ArenaListener implements Listener {
                 Bukkit.getScheduler().scheduleSyncRepeatingTask(Main.plugin, task.updateBar, 0, Utils.secondsToTicks(1)));
 
         // Schedule and record calibration task
-        task.getTasks().put(task.calibrate, Bukkit.getScheduler().scheduleSyncRepeatingTask(Main.plugin, task.calibrate, 0,
-                Utils.secondsToTicks(10)));
+        task.getTasks().put(task.calibrate, Bukkit.getScheduler().scheduleSyncRepeatingTask(Main.plugin, task.calibrate,
+                0, Utils.secondsToTicks(1)));
 
         // Spawn mobs
         spawnVillagers(arena);

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/GameListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/GameListener.java
@@ -82,12 +82,7 @@ public class GameListener implements Listener {
 			data = new DataManager("spawnTables/a" + arena.getId() + ".yml");
 		else data = new DataManager("spawnTables/" + arena.getSpawnTableFile() + ".yml");
 
-		// Update villager count
-		if (ent instanceof Villager)
-			arena.decrementVillagers();
-
-		// Update wolf count
-		else if (ent instanceof Wolf) {
+		if (ent instanceof Wolf) {
 			try {
 				arena.getPlayer((Player) ((Wolf) ent).getOwner()).decrementWolves();
 			} catch (Exception err) {
@@ -96,9 +91,8 @@ public class GameListener implements Listener {
 		}
 
 		// Update iron golem count
-		else if (ent instanceof IronGolem) {
+		else if (ent instanceof IronGolem)
 			arena.decrementGolems();
-		}
 
 		// Manage drops and update enemy count, update player kill count
 		else {
@@ -137,9 +131,6 @@ public class GameListener implements Listener {
 				}
 				if (arena.hasExpDrop())
 					e.setDroppedExp((int) (arena.getCurrentDifficulty() * 2));
-
-				// Decrement enemy count
-				arena.decrementEnemies();
 			}
 
 			// Get wave
@@ -172,42 +163,6 @@ public class GameListener implements Listener {
 	public void onGameModeSwitch(PlayerGameModeChangeEvent e) {
 		if (GameManager.checkPlayer(e.getPlayer()) && e.getNewGameMode() == GameMode.SURVIVAL)
 			e.setCancelled(true);
-	}
-
-	// Handle creeper explosions
-	@EventHandler
-	public void onExplode(ExplosionPrimeEvent e) {
-
-		Entity ent = e.getEntity();
-
-		// Check for arena enemies
-		if (!ent.hasMetadata("VD"))
-			return;
-
-		Arena arena = GameManager.getArena(ent.getMetadata("VD").get(0).asInt());
-
-		// Check for right game
-		if (!ent.hasMetadata("game"))
-			return;
-		if (ent.getMetadata("game").get(0).asInt() != arena.getGameID())
-			return;
-
-		// Arena enemies not part of an active arena
-		if (arena.getStatus() != ArenaStatus.ACTIVE)
-			return;
-
-		// Check for right wave
-		if (!ent.hasMetadata("wave"))
-			return;
-		if (ent.getMetadata("wave").get(0).asInt() != arena.getCurrentWave())
-			return;
-
-		// Decrement enemy count
-		arena.decrementEnemies();
-
-		// Update scoreboards
-		Bukkit.getScheduler().scheduleSyncDelayedTask(Main.plugin, () ->
-				Bukkit.getPluginManager().callEvent(new ReloadBoardsEvent(arena)));
 	}
 
 	// Save gems from explosions


### PR DESCRIPTION
- Removed checking and updating of enemy count and villager count on kill or spawn
- Increased calibration frequency from 10s to 1s