### PR TITLE
Bug fix and achievement rebalance

### DIFF
--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/Main.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/Main.java
@@ -136,8 +136,10 @@ public class Main extends JavaPlugin {
 				.setTabCompleter(new CommandTab());
 
 		// Schedule to register PAPI expansion
-		Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> new VDExpansion().register(),
-				Utils.secondsToTicks(1));
+		Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
+			if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null)
+				new VDExpansion().register();
+			}, Utils.secondsToTicks(1));
 
 		// Set up initial classes
 		saveDefaultConfig();

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/displays/Leaderboard.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/displays/Leaderboard.java
@@ -61,6 +61,7 @@ public class Leaderboard {
 		// Put names and values into the leaderboard
 		mapping.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
 				.filter(set -> Bukkit.getOfflinePlayer(UUID.fromString(set.getKey())).getName() != null)
+				.filter(set -> set.getValue() > 0)
 				.limit(10).forEachOrdered(set -> {
 					try {
 						info.add(Bukkit.getOfflinePlayer(UUID.fromString(set.getKey())).getName() +

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
@@ -524,7 +524,7 @@ public class ArenaListener implements Listener {
         // Notify players that the game has ended (Title)
         arena.getPlayers().forEach(player ->
                 player.getPlayer().sendTitle(CommunicationManager.format("&4&l" +
-                        LanguageManager.messages.gameOver), "", Utils.secondsToTicks(.5),
+                        LanguageManager.messages.gameOver), " ", Utils.secondsToTicks(.5),
                         Utils.secondsToTicks(2.5), Utils.secondsToTicks(1)));
 
         // Notify players that the game has ended (Chat)

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
@@ -556,10 +556,10 @@ public class ArenaListener implements Listener {
             // Give persistent rewards
             arena.getActives().forEach(vdPlayer -> {
                 // Calculate reward from difficulty multiplier, wave, kills, and gem balance
-                int reward = (10 + 5 * arena.getDifficultyMultiplier()) *
+                int reward = (5 * arena.getDifficultyMultiplier()) *
                         (Math.max(arena.getCurrentWave() - vdPlayer.getJoinedWave() - 1, 0));
                 reward += vdPlayer.getKills();
-                reward += (vdPlayer.getGems() + 5) / 10;
+                reward += (vdPlayer.getGems() + 25) / 50;
 
                 // Calculate challenge bonuses
                 int bonus = 0;

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/GameListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/GameListener.java
@@ -639,7 +639,6 @@ public class GameListener implements Listener {
 		FileConfiguration playerData = Main.plugin.getPlayerData();
 		String path = player.getUniqueId() + ".achievements";
 		Random random = new Random();
-
 		if (playerData.contains(path) && gamer.isBoosted() && random.nextDouble() < .1 &&
 				playerData.getStringList(path).contains(Achievement.allChallenges().getID())) {
 			PlayerManager.giveTotemEffect(player);

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -2880,8 +2880,8 @@ public class InventoryListener implements Listener {
 			buy = ItemManager.removeLastLore(buy);
 
 			// Make unbreakable for blacksmith (not sharing)
-			if ((Kit.blacksmith().getName().equals(gamer.getKit().getName()) ||
-					Kit.blacksmith().getName().equals(gamer.getKit2().getName())) && !gamer.isSharing())
+			if ((Kit.blacksmith().setKitLevel(1).equals(gamer.getKit()) ||
+					Kit.blacksmith().setKitLevel(1).equals(gamer.getKit2())) && !gamer.isSharing())
 				buy = ItemManager.makeUnbreakable(buy);
 
 			// Make unbreakable for successful blacksmith sharing
@@ -2891,8 +2891,8 @@ public class InventoryListener implements Listener {
 			}
 
 			// Make splash potion for witch (not sharing)
-			if ((Kit.witch().getName().equals(gamer.getKit().getName()) ||
-					Kit.witch().getName().equals(gamer.getKit2().getName())) && !gamer.isSharing())
+			if ((Kit.witch().setKitLevel(1).equals(gamer.getKit()) ||
+					Kit.witch().setKitLevel(1).equals(gamer.getKit2())) && !gamer.isSharing())
 				buy = ItemManager.makeSplash(buy);
 
 			// Make splash potion for successful witch sharing
@@ -2903,8 +2903,8 @@ public class InventoryListener implements Listener {
 
 			// Subtract from balance, apply rebate, and update scoreboard
 			gamer.addGems(-cost);
-			if ((Kit.merchant().getName().equals(gamer.getKit().getName()) ||
-					Kit.merchant().getName().equals(gamer.getKit2().getName())) && !gamer.isSharing())
+			if ((Kit.merchant().setKitLevel(1).equals(gamer.getKit()) ||
+					Kit.merchant().setKitLevel(1).equals(gamer.getKit2())) && !gamer.isSharing())
 				gamer.addGems(cost / 10);
 			if (random.nextDouble() > Math.pow(.75, arenaInstance.effectShareCount(EffectType.MERCHANT))) {
 				gamer.addGems(cost / 10);

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -3131,6 +3131,9 @@ public class InventoryListener implements Listener {
 				playerData.set(player.getUniqueId().toString(), null);
 				Main.plugin.savePlayerData();
 
+				// Reload leaderboards
+				GameManager.refreshLeaderboards();
+
 				// Confirm and return
 				PlayerManager.notifySuccess(player, LanguageManager.confirms.reset);
 				player.openInventory(Inventories.createPlayerStatsMenu(meta.getPlayer()));


### PR DESCRIPTION
### Changes
- Fixed a bug where the game would crash because the shop couldn't handle players without two kits
- Resetting stats now automatically refreshes leaderboards
- Leaderboards now ignore entries with values of 0
- Fixed an issue that kicked players upon game end
- Fixed an issue where PAPI was not properly checked on plugin enable
- Base crystal from waves went from 15-30 per wave to 5-20 per wave
- Base crystal from gem balance now rounded to nearest 50 instead of 10