### PR TITLE
Hotfix 1.2.4

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/common/src/main/java/me/theguyhere/villagerdefense/common/CommunicationManager.java
+++ b/common/src/main/java/me/theguyhere/villagerdefense/common/CommunicationManager.java
@@ -160,7 +160,7 @@ public class CommunicationManager {
      * @return Formatted message prepared to be sent to the player.
      */
     public static String namedNotify(ColoredMessage name, String msg) {
-        return format("&2[VD] " + name.toString() + "&f: " + msg);
+        return format("&2[VD] " + name.toString() + ":&f " + msg);
     }
 
     public static void debugError(String msg, int debugLevel) {

--- a/nms/common/pom.xml
+++ b/nms/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/pom.xml
+++ b/nms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_16_r3/pom.xml
+++ b/nms/v1_16_r3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_17_r1/pom.xml
+++ b/nms/v1_17_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_18_r1/pom.xml
+++ b/nms/v1_18_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_18_r2/pom.xml
+++ b/nms/v1_18_r2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_19_r1/pom.xml
+++ b/nms/v1_19_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.3</version>
+        <version>1.2.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/commands/Commands.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/commands/Commands.java
@@ -118,7 +118,7 @@ public class Commands implements CommandExecutor {
 											return true;
 										}
 
-										GameManager.setLobby(player.getLocation());
+										GameManager.saveLobby(player.getLocation());
 										PlayerManager.notifySuccess(player, "Lobby set!");
 										return true;
 
@@ -2445,8 +2445,7 @@ public class Commands implements CommandExecutor {
 						fixed = true;
 
 						// Fix
-						Main.plugin.saveResource("default.yml", true);
-						Main.plugin.getConfig().set("spawnTableStructure", Main.spawnTableVersion);
+						Main.plugin.saveResource("spawnTables/default.yml", true);
 						Main.plugin.getConfig().set("spawnTableDefault", Main.defaultSpawnVersion);
 						Main.plugin.saveConfig();
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/GameManager.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/GameManager.java
@@ -224,8 +224,22 @@ public class GameManager {
 		return lobby;
 	}
 
+	/**
+	 * Set the cached lobby in {@link GameManager}.
+	 * DOES NOT CHANGE THE STORED LOBBY FOR THE SERVER
+	 * @param lobby Lobby location.
+	 */
 	public static void setLobby(Location lobby) {
 		GameManager.lobby = lobby;
+	}
+
+	/**
+	 * Saves a new lobby for the server and changes the cached lobby.
+	 * @param lobby Lobby location.
+	 */
+	public static void saveLobby(Location lobby) {
+		DataManager.setConfigurationLocation("lobby", lobby);
+		setLobby(lobby);
 	}
 
 	public static void reloadLobby() {

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/Tasks.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/game/models/Tasks.java
@@ -495,7 +495,7 @@ public class Tasks {
 				Bukkit.getScheduler().scheduleSyncDelayedTask(Main.plugin, () -> arena.getActives().forEach(player ->
 						player.getPlayer().sendTitle(CommunicationManager.format(
 								"&6" + LanguageManager.messages.shopUpgrade),
-								"&7" + CommunicationManager.format(
+								CommunicationManager.format("&7" +
 										String.format(LanguageManager.messages.shopInfo, "10")),
 								Utils.secondsToTicks(.5), Utils.secondsToTicks(2.5),
 								Utils.secondsToTicks(1))), Utils.secondsToTicks(4));

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/ArenaListener.java
@@ -83,6 +83,7 @@ public class ArenaListener implements Listener {
         if (Main.plugin.getConfig().getBoolean("keepInv")) {
             // Save player exp and items before going into arena
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".health", player.getHealth());
+            Main.plugin.getPlayerData().set(player.getUniqueId() + ".absorption", player.getAbsorptionAmount());
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".food", player.getFoodLevel());
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".saturation", (double) player.getSaturation());
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".level", player.getLevel());
@@ -487,6 +488,9 @@ public class ArenaListener implements Listener {
             if (Main.plugin.getPlayerData().contains(player.getUniqueId() + ".health"))
                 player.setHealth(Main.plugin.getPlayerData().getDouble(player.getUniqueId() + ".health"));
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".health", null);
+            if (Main.plugin.getPlayerData().contains(player.getUniqueId() + ".absorption"))
+                player.setAbsorptionAmount(Main.plugin.getPlayerData().getDouble(player.getUniqueId() + ".absorption"));
+            Main.plugin.getPlayerData().set(player.getUniqueId() + ".absorption", null);
             if (Main.plugin.getPlayerData().contains(player.getUniqueId() + ".food"))
                 player.setFoodLevel(Main.plugin.getPlayerData().getInt(player.getUniqueId() + ".food"));
             Main.plugin.getPlayerData().set(player.getUniqueId() + ".food", null);

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -2841,7 +2841,8 @@ public class InventoryListener implements Listener {
 		else if (invID == InventoryID.MOCK_CUSTOM_SHOP_MENU) {
 			if (buttonName.contains(LanguageManager.messages.exit))
 				try {
-					player.openInventory(Inventories.createArenaInfoMenu(GameManager.getArena(title.substring(19))));
+					player.openInventory(Inventories.createArenaInfoMenu(GameManager.getArena(
+							title.substring(6 + LanguageManager.names.customShop.length()))));
 				} catch (ArenaNotFoundException ignored) {
 				}
 		}
@@ -2878,7 +2879,8 @@ public class InventoryListener implements Listener {
 			if (lore == null)
 				return;
 
-			int cost = Integer.parseInt(lore.get(lore.size() - 1).substring(10));
+			int cost = Integer.parseInt(lore.get(lore.size() - 1)
+					.substring(6 + LanguageManager.messages.gems.length()));
 			Random random = new Random();
 
 			// Check if they can afford the item

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/InventoryListener.java
@@ -73,6 +73,50 @@ public class InventoryListener implements Listener {
 		else meta.getArena().setCommunityChest(e.getInventory());
 	}
 
+	// Prevent items from being removed from the game
+	@EventHandler
+	public void onDragOther(InventoryDragEvent e) {
+		// Ignore plugin inventories
+		if (e.getInventory().getHolder() instanceof InventoryMeta)
+			return;
+
+		// Ignore clicks in player inventory
+		if (e.getInventory().getType() == InventoryType.PLAYER)
+			return;
+
+		// Ignore players that aren't part of an arena
+		Player player = (Player) e.getWhoClicked();
+		try {
+			GameManager.getArena(player);
+		} catch (ArenaNotFoundException err) {
+			return;
+		}
+
+		// Cancel event
+		e.setCancelled(true);
+	}
+	@EventHandler
+	public void onClickOther(InventoryClickEvent e) {
+		// Ignore plugin inventories
+		if (e.getInventory().getHolder() instanceof InventoryMeta)
+			return;
+
+		// Ignore clicks in player inventory
+		if (e.getInventory().getType() == InventoryType.PLAYER || e.getView().getType() == InventoryType.CRAFTING)
+			return;
+
+		// Ignore players that aren't part of an arena
+		Player player = (Player) e.getWhoClicked();
+		try {
+			GameManager.getArena(player);
+		} catch (ArenaNotFoundException err) {
+			return;
+		}
+
+		// Cancel event
+		e.setCancelled(true);
+	}
+
 	// All click events in the inventories
 	@EventHandler
 	public void onClick(InventoryClickEvent e) {

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/JoinListener.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/JoinListener.java
@@ -51,6 +51,9 @@ public class JoinListener implements Listener {
 				if (playerData.contains(player.getUniqueId() + ".health"))
 					player.setHealth(playerData.getDouble(player.getUniqueId() + ".health"));
 				playerData.set(player.getUniqueId() + ".health", null);
+				if (playerData.contains(player.getUniqueId() + ".absorption"))
+					player.setAbsorptionAmount(playerData.getDouble(player.getUniqueId() + ".absorption"));
+				playerData.set(player.getUniqueId() + ".absorption", null);
 				if (playerData.contains(player.getUniqueId() + ".food"))
 					player.setFoodLevel(playerData.getInt(player.getUniqueId() + ".food"));
 				playerData.set(player.getUniqueId() + ".food", null);

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/PacketListenerImp.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/PacketListenerImp.java
@@ -45,7 +45,7 @@ public class PacketListenerImp implements PacketListener {
 
         try {
             arena = GameManager.getArena(Integer.parseInt(header.substring(18, header.length() - 4)));
-        } catch (ArenaNotFoundException ignored) {
+        } catch (ArenaNotFoundException | NumberFormatException e) {
             return;
         }
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/PacketListenerImp.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/listeners/PacketListenerImp.java
@@ -45,7 +45,7 @@ public class PacketListenerImp implements PacketListener {
 
         try {
             arena = GameManager.getArena(Integer.parseInt(header.substring(18, header.length() - 4)));
-        } catch (ArenaNotFoundException | NumberFormatException e) {
+        } catch (ArenaNotFoundException | NumberFormatException | IndexOutOfBoundsException e) {
             return;
         }
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/tools/PlayerManager.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/tools/PlayerManager.java
@@ -52,6 +52,7 @@ public class PlayerManager {
         if (!maxHealth.getModifiers().isEmpty())
             maxHealth.getModifiers().forEach(maxHealth::removeModifier);
         player.setHealth(maxHealth.getValue());
+        player.setAbsorptionAmount(0);
         player.setFoodLevel(20);
         player.setSaturation(20);
         player.setExp(0);

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.theguyhere.villagerdefense.plugin.Main
 name: VillagerDefense
-version: 1.2.3
+version: 1.2.4
 author: Theguyhere
 api-version: 1.16
 softdepend: [WorldGuard, WorldEdit, Multiverse-core, PlaceholderAPI]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>me.theguyhere</groupId>
     <artifactId>VillagerDefense-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <name>VillagerDefense Parent</name>
 
     <modules>


### PR DESCRIPTION
### Changes
- Fixed a bug where the colon was white when NPCs were speaking
- Fixed a bug that didn't allow default.yml to regenerate
- Fixed a bug where the version of the spawn table structure would update even though no auto-updates were made
- Fixed a typo with the shop upgrade title message
- Fixed a bug that didn't save a player's absorption from survival
- Fixed a bug where using commands to set a new lobby didn't actually set one
- Fixed a bug not allowing players to leave the mockup of the custom shop
- Fixed a bug that would cause buying to break when the "gems" key of the language file is changed
- Fixed a bug that would throw an error in the console when the naming sign was edited and messed up by the user
- Fixed a bug that allowed players to save VD items in chests or ender chests, potentially causing issues if it wasn't addressed by map design