### PR TITLE
Add 1.20.5/6 support

### DIFF
--- a/nms/pom.xml
+++ b/nms/pom.xml
@@ -24,6 +24,7 @@
         <module>v1_20_r1</module>
         <module>v1_20_r2</module>
         <module>v1_20_r3</module>
+        <module>v1_20_r4</module>
         <module>common</module>
     </modules>
 </project>

--- a/nms/v1_20_r4/pom.xml
+++ b/nms/v1_20_r4/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>VillagerDefense-nms</artifactId>
+        <groupId>me.theguyhere</groupId>
+        <version>1.2.10</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>VillagerDefense-nms-v1_20_r4</artifactId>
+    <name>VillagerDefense NMS v1_20_R4</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>me.theguyhere</groupId>
+            <artifactId>VillagerDefense-nms-common</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherKey.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherKey.java
@@ -1,0 +1,55 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import io.netty.handler.codec.EncoderException;
+import net.minecraft.network.chat.IChatBaseComponent;
+import net.minecraft.network.syncher.DataWatcherRegistry;
+import net.minecraft.network.syncher.DataWatcherSerializer;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
+
+/**
+ * A class to simplify interactions with serializing and managing DataWatchers.
+ *
+ * This class was borrowed from filoghost to learn about using DataWatchers.
+ * @param <T>
+ */
+class DataWatcherKey<T> {
+    private static final DataWatcherSerializer<Byte> BYTE_SERIALIZER = DataWatcherRegistry.a;
+    private static final DataWatcherSerializer<Integer> INT_SERIALIZER = DataWatcherRegistry.b;
+    private static final DataWatcherSerializer<Boolean> BOOLEAN_SERIALIZER = DataWatcherRegistry.k;
+    private static final DataWatcherSerializer<ItemStack> ITEM_STACK_SERIALIZER = DataWatcherRegistry.h;
+    private static final DataWatcherSerializer<Optional<IChatBaseComponent>> OPTIONAL_CHAT_COMPONENT_SERIALIZER = DataWatcherRegistry.g;
+
+    static final DataWatcherKey<Byte> ENTITY_STATUS = new DataWatcherKey<>(0, BYTE_SERIALIZER);
+    static final DataWatcherKey<Optional<IChatBaseComponent>> CUSTOM_NAME = new DataWatcherKey<>(2, OPTIONAL_CHAT_COMPONENT_SERIALIZER);
+    static final DataWatcherKey<Boolean> CUSTOM_NAME_VISIBILITY = new DataWatcherKey<>(3, BOOLEAN_SERIALIZER);
+    static final DataWatcherKey<ItemStack> ITEM_STACK = new DataWatcherKey<>(8, ITEM_STACK_SERIALIZER);
+    static final DataWatcherKey<Byte> ARMOR_STAND_STATUS = new DataWatcherKey<>(15, BYTE_SERIALIZER);
+    static final DataWatcherKey<Integer> SLIME_SIZE = new DataWatcherKey<>(16, INT_SERIALIZER);
+
+    private final int index;
+    private final DataWatcherSerializer<T> serializer;
+    private final int serializerTypeID;
+
+    private DataWatcherKey(int index, DataWatcherSerializer<T> serializer) {
+        this.index = index;
+        this.serializer = serializer;
+        this.serializerTypeID = DataWatcherRegistry.b(serializer);
+        if (serializerTypeID < 0) {
+            throw new EncoderException("Could not find serializer ID of " + serializer);
+        }
+    }
+
+    int getIndex() {
+        return index;
+    }
+
+    DataWatcherSerializer<T> getSerializer() {
+        return serializer;
+    }
+
+    int getSerializerTypeID() {
+        return serializerTypeID;
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherPacketBuilder.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherPacketBuilder.java
@@ -1,0 +1,56 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import net.minecraft.network.chat.IChatBaseComponent;
+import org.apache.logging.log4j.util.Strings;
+import org.bukkit.craftbukkit.v1_20_R3.util.CraftChatMessage;
+
+import java.util.Optional;
+
+/**
+ * Class to help build DataWatchers.
+ *
+ * This class was borrowed from filoghost.
+ * @param <T> Packet type.
+ */
+abstract class DataWatcherPacketBuilder<T> {
+    private final PacketSetter packetSetter;
+
+    DataWatcherPacketBuilder(PacketSetter packetSetter) {
+        this.packetSetter = packetSetter;
+    }
+
+    DataWatcherPacketBuilder<T> setInvisible() {
+        packetSetter.writeDataWatcherEntry(DataWatcherKey.ENTITY_STATUS, (byte) 0x20); // Invisible
+        return this;
+    }
+
+    DataWatcherPacketBuilder<T> setArmorStandMarker() {
+        setInvisible();
+        packetSetter.writeDataWatcherEntry(
+                DataWatcherKey.ARMOR_STAND_STATUS, (byte) (0x01 | 0x02 | 0x08 | 0x10)); // Small, no gravity, no base plate, marker
+        return this;
+    }
+
+    DataWatcherPacketBuilder<T> setCustomName(String customName) {
+        packetSetter.writeDataWatcherEntry(DataWatcherKey.CUSTOM_NAME, getCustomNameDataWatcherValue(customName));
+        packetSetter.writeDataWatcherEntry(DataWatcherKey.CUSTOM_NAME_VISIBILITY, !Strings.isEmpty(customName));
+        return this;
+    }
+
+    private Optional<IChatBaseComponent> getCustomNameDataWatcherValue(String customName) {
+        if (customName.length() > 300)
+            customName = customName.substring(0, 300);
+        if (!Strings.isEmpty(customName)) {
+            return Optional.of(CraftChatMessage.fromString(customName, false, true)[0]);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    T build() {
+        packetSetter.writeDataWatcherEntriesEnd();
+        return createPacket(packetSetter);
+    }
+
+    abstract T createPacket(PacketSetter packetSetter);
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherPacketBuilder.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/DataWatcherPacketBuilder.java
@@ -2,7 +2,7 @@ package me.theguyhere.villagerdefense.nms.v1_20_r4;
 
 import net.minecraft.network.chat.IChatBaseComponent;
 import org.apache.logging.log4j.util.Strings;
-import org.bukkit.craftbukkit.v1_20_R3.util.CraftChatMessage;
+import org.bukkit.craftbukkit.v1_20_R4.util.CraftChatMessage;
 
 import java.util.Optional;
 

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityDestroyPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityDestroyPacket.java
@@ -1,0 +1,29 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityDestroy;
+
+/**
+ * Packet class for destroying entities.
+ *
+ * This class format was borrowed from filoghost.
+ */
+class EntityDestroyPacket extends VersionNMSPacket {
+    private final Packet<?> rawPacket;
+
+    EntityDestroyPacket(EntityID entityID) {
+        PacketSetter packetSetter = PacketSetter.get();
+
+        // Write ID of entity to destroy
+        packetSetter.writeVarIntArray(entityID.getNumericID());
+
+        // Send out packet
+        rawPacket = new PacketPlayOutEntityDestroy(packetSetter.a());
+    }
+
+    @Override
+    Packet<?> getRawPacket() {
+        return rawPacket;
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityHeadRotationPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityHeadRotationPacket.java
@@ -19,8 +19,9 @@ public class EntityHeadRotationPacket extends VersionNMSPacket {
 
         // Head yaw
         packetSetter.writeByte(Utils.degreesToByte(headYaw));
+        PacketPlayOutEntityHeadRotation.a.a();
 
-        rawPacket = new PacketPlayOutEntityHeadRotation(packetSetter);
+        rawPacket = PacketPlayOutEntityHeadRotation.a.decode(packetSetter);
     }
 
     @Override

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityHeadRotationPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityHeadRotationPacket.java
@@ -1,0 +1,30 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.common.Utils;
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityHeadRotation;
+
+/**
+ * Class for sending entity head rotation packets.
+ */
+public class EntityHeadRotationPacket extends VersionNMSPacket {
+    private final Packet<?> rawPacket;
+
+    EntityHeadRotationPacket(EntityID entityID, float headYaw) {
+        PacketSetter packetSetter = PacketSetter.get();
+
+        // Entity info
+        packetSetter.writeVarInt(entityID.getNumericID());
+
+        // Head yaw
+        packetSetter.writeByte(Utils.degreesToByte(headYaw));
+
+        rawPacket = new PacketPlayOutEntityHeadRotation(packetSetter);
+    }
+
+    @Override
+    Packet<?> getRawPacket() {
+        return rawPacket;
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityMetadataPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityMetadataPacket.java
@@ -1,0 +1,40 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+
+/**
+ * A class for sending entity metadata packets.
+ *
+ * This class format was borrowed from filoghost.
+ */
+class EntityMetadataPacket extends VersionNMSPacket {
+    private final Packet<?> rawPacket;
+
+    private EntityMetadataPacket(PacketSetter packetSetter) {
+        rawPacket = new PacketPlayOutEntityMetadata(packetSetter);
+    }
+
+    @Override
+    Packet<?> getRawPacket() {
+        return rawPacket;
+    }
+
+    public static DataWatcherPacketBuilder<EntityMetadataPacket> builder(EntityID entityID) {
+        PacketSetter packetSetter = PacketSetter.get();
+        packetSetter.writeVarInt(entityID.getNumericID());
+        return new Builder(packetSetter);
+    }
+
+    private static class Builder extends DataWatcherPacketBuilder<EntityMetadataPacket> {
+        private Builder(PacketSetter packetSetter) {
+            super(packetSetter);
+        }
+
+        @Override
+        EntityMetadataPacket createPacket(PacketSetter packetSetter) {
+            return new EntityMetadataPacket(packetSetter);
+        }
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityMetadataPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityMetadataPacket.java
@@ -1,8 +1,10 @@
 package me.theguyhere.villagerdefense.nms.v1_20_r4;
 
 import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.PacketPlayOutEntityMetadata;
+import net.minecraft.server.MinecraftServer;
 
 /**
  * A class for sending entity metadata packets.
@@ -13,7 +15,7 @@ class EntityMetadataPacket extends VersionNMSPacket {
     private final Packet<?> rawPacket;
 
     private EntityMetadataPacket(PacketSetter packetSetter) {
-        rawPacket = new PacketPlayOutEntityMetadata(packetSetter);
+        rawPacket = PacketPlayOutEntityMetadata.a.decode(new RegistryFriendlyByteBuf(packetSetter, MinecraftServer.getServer().bc()));
     }
 
     @Override

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityTypeID.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityTypeID.java
@@ -2,6 +2,6 @@ package me.theguyhere.villagerdefense.nms.v1_20_r4;
 
 // Find using https://pokechu22.github.io/Burger/${version}.html
 class EntityTypeID {
-    static final int ARMOR_STAND = 2;
-    static final int VILLAGER = 109;
+    static final int ARMOR_STAND = 3;
+    static final int VILLAGER = 113;
 }

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityTypeID.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/EntityTypeID.java
@@ -1,0 +1,7 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+// Find using https://pokechu22.github.io/Burger/${version}.html
+class EntityTypeID {
+    static final int ARMOR_STAND = 2;
+    static final int VILLAGER = 109;
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/InboundPacketHandler.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/InboundPacketHandler.java
@@ -1,0 +1,49 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import me.theguyhere.villagerdefense.common.CommunicationManager;
+import me.theguyhere.villagerdefense.common.Utils;
+import me.theguyhere.villagerdefense.nms.common.NMSErrors;
+import me.theguyhere.villagerdefense.nms.common.PacketListener;
+import net.minecraft.network.protocol.game.PacketPlayInUseEntity;
+import org.bukkit.entity.Player;
+
+/**
+ * Class borrowed from filoghost.
+ */
+class InboundPacketHandler extends ChannelInboundHandlerAdapter {
+    public static final String HANDLER_NAME = "villager_defense_listener";
+    private final Player player;
+    private final PacketListener packetListener;
+
+    InboundPacketHandler(Player player, PacketListener packetListener) {
+        this.player = player;
+        this.packetListener = packetListener;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext context, Object packet) throws Exception {
+        try {
+            if (packet instanceof PacketPlayInUseEntity) {
+                int entityID = (int) Utils.getFieldValue(packet, "a");
+
+                // Left click
+                if (Utils.getFieldValue(packet, "b").getClass().getDeclaredFields().length == 0) {
+                    packetListener.onAttack(player, entityID);
+                }
+
+                // Main hand right click
+                else if (Utils.getFieldValue(packet, "b").getClass().getDeclaredFields().length == 1
+                        && Utils.getFieldValue(Utils.getFieldValue(packet, "b"), "a")
+                        .toString().equalsIgnoreCase("MAIN_HAND")) {
+                    packetListener.onInteractMain(player, entityID);
+                }
+            }
+        } catch (Exception e) {
+            CommunicationManager.debugError(NMSErrors.EXCEPTION_ON_PACKET_READ, 0);
+            e.printStackTrace();
+        }
+        super.channelRead(context, packet);
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/InboundPacketHandler.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/InboundPacketHandler.java
@@ -26,16 +26,16 @@ class InboundPacketHandler extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext context, Object packet) throws Exception {
         try {
             if (packet instanceof PacketPlayInUseEntity) {
-                int entityID = (int) Utils.getFieldValue(packet, "a");
+                int entityID = (int) Utils.getFieldValue(packet, "b");
 
                 // Left click
-                if (Utils.getFieldValue(packet, "b").getClass().getDeclaredFields().length == 0) {
+                if (Utils.getFieldValue(packet, "c").getClass().getDeclaredFields().length == 0) {
                     packetListener.onAttack(player, entityID);
                 }
 
                 // Main hand right click
-                else if (Utils.getFieldValue(packet, "b").getClass().getDeclaredFields().length == 1
-                        && Utils.getFieldValue(Utils.getFieldValue(packet, "b"), "a")
+                else if (Utils.getFieldValue(packet, "c").getClass().getDeclaredFields().length == 1
+                        && Utils.getFieldValue(Utils.getFieldValue(packet, "c"), "a")
                         .toString().equalsIgnoreCase("MAIN_HAND")) {
                     packetListener.onInteractMain(player, entityID);
                 }

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketEntityArmorStand.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketEntityArmorStand.java
@@ -1,0 +1,35 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import me.theguyhere.villagerdefense.nms.common.PacketGroup;
+import me.theguyhere.villagerdefense.nms.common.entities.TextPacketEntity;
+import org.bukkit.Location;
+
+/**
+ * An armor stand entity constructed out of packets.
+ *
+ * Class structure borrowed from filoghost.
+ */
+class PacketEntityArmorStand implements TextPacketEntity {
+    private final EntityID armorStandID;
+
+    PacketEntityArmorStand(EntityID armorStandID) {
+        this.armorStandID = armorStandID;
+    }
+
+    @Override
+    public PacketGroup newDestroyPackets() {
+        return new EntityDestroyPacket(armorStandID);
+    }
+
+    @Override
+    public PacketGroup newSpawnPackets(Location location, String text) {
+        return PacketGroup.of(
+                new SpawnEntityPacket(armorStandID, EntityTypeID.ARMOR_STAND, location),
+                EntityMetadataPacket.builder(armorStandID)
+                        .setArmorStandMarker()
+                        .setCustomName(text)
+                        .build()
+        );
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketEntityVillager.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketEntityVillager.java
@@ -1,0 +1,35 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import me.theguyhere.villagerdefense.nms.common.PacketGroup;
+import me.theguyhere.villagerdefense.nms.common.entities.VillagerPacketEntity;
+import org.bukkit.Location;
+
+/**
+ * A villager entity constructed out of packets.
+ */
+class PacketEntityVillager implements VillagerPacketEntity {
+    private final EntityID villagerID;
+
+    PacketEntityVillager(EntityID villagerID) {
+        this.villagerID = villagerID;
+    }
+
+    @Override
+    public PacketGroup newDestroyPackets() {
+        return new EntityDestroyPacket(villagerID);
+    }
+
+    @Override
+    public PacketGroup newSpawnPackets(Location location) {
+        return PacketGroup.of(
+                new SpawnEntityPacket(villagerID, EntityTypeID.VILLAGER, location, location.getPitch()),
+                new EntityHeadRotationPacket(villagerID, location.getYaw())
+        );
+    }
+
+    @Override
+    public int getEntityID() {
+        return villagerID.getNumericID();
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketSetter.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketSetter.java
@@ -1,0 +1,73 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.core.BlockPosition;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketDataSerializer;
+
+import java.util.UUID;
+
+/**
+ * A class to help with setting up a packet for a specific version.
+ *
+ * This class was borrowed from filoghost to learn about Packets.
+ */
+class PacketSetter extends PacketDataSerializer {
+
+    /** Keeps an instance so new ones don't need to be instantiated (don't know why but filoghost did it).*/
+    private static final PacketSetter INSTANCE = new PacketSetter();
+
+    /**
+     * Get the instance of me.theguyhere.villagedefense.nms.v1_18_r1.PacketSetter for this version.
+     * @return me.theguyhere.villagedefense.nms.v1_18_r1.PacketSetter for specific version.
+     */
+    static PacketSetter get() {
+        INSTANCE.clear();
+        return INSTANCE;
+    }
+
+    /**
+     * Create instance once on class load.
+     */
+    private PacketSetter() {
+        super(Unpooled.buffer());
+    }
+
+
+    void writeVarInt(int i) {
+        super.c(i);
+    }
+
+    void writeVarIntArray(int i1) {
+        writeVarInt(1);
+        writeVarInt(i1);
+    }
+
+    void writeVarIntArray(int i1, int i2) {
+        writeVarInt(2);
+        writeVarInt(i1);
+        writeVarInt(i2);
+    }
+
+    void writeUUID(UUID uuid) {
+        super.a(uuid);
+    }
+
+    void writePosition(BlockPosition position) {
+        super.a(position);
+    }
+
+    void writeNBTTagCompound(NBTTagCompound nbtTagCompound) {
+        super.a(nbtTagCompound);
+    }
+
+    <T> void writeDataWatcherEntry(DataWatcherKey<T> key, T value) {
+        writeByte(key.getIndex());
+        writeVarInt(key.getSerializerTypeID());
+        key.getSerializer().a(this, value);
+    }
+
+    void writeDataWatcherEntriesEnd() {
+        writeByte(0xFF);
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketSetter.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/PacketSetter.java
@@ -4,6 +4,8 @@ import io.netty.buffer.Unpooled;
 import net.minecraft.core.BlockPosition;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketDataSerializer;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.server.MinecraftServer;
 
 import java.util.UUID;
 
@@ -64,7 +66,7 @@ class PacketSetter extends PacketDataSerializer {
     <T> void writeDataWatcherEntry(DataWatcherKey<T> key, T value) {
         writeByte(key.getIndex());
         writeVarInt(key.getSerializerTypeID());
-        key.getSerializer().a(this, value);
+        key.getSerializer().codec().encode(new RegistryFriendlyByteBuf(this, MinecraftServer.getServer().bc()), value);
     }
 
     void writeDataWatcherEntriesEnd() {

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/SpawnEntityPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/SpawnEntityPacket.java
@@ -1,0 +1,61 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.common.Utils;
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import org.bukkit.Location;
+
+/**
+ * Packet class for spawning entities.
+ *
+ * This class format was borrowed from filoghost.
+ */
+class SpawnEntityPacket extends VersionNMSPacket {
+    private final Packet<?> rawPacket;
+
+    SpawnEntityPacket(EntityID entityID, int entityTypeID, Location location) {
+        this(entityID, entityTypeID, location, 0, 0);
+    }
+
+    SpawnEntityPacket(EntityID entityID, int entityTypeID, Location location, float headPitch) {
+        this(entityID, entityTypeID, location, headPitch, 0);
+    }
+
+    SpawnEntityPacket(EntityID entityID, int entityTypeID, Location location, float headPitch, int objectData) {
+        PacketSetter packetSetter = PacketSetter.get();
+
+        // Entity info
+        packetSetter.writeVarInt(entityID.getNumericID());
+        packetSetter.writeUUID(entityID.getUUID());
+        packetSetter.writeVarInt(entityTypeID);
+
+        // Position
+        packetSetter.writeDouble(location.getX());
+        packetSetter.writeDouble(location.getY());
+        packetSetter.writeDouble(location.getZ());
+
+        // Rotation
+        packetSetter.writeByte(Utils.degreesToByte(location.getPitch()));
+        packetSetter.writeByte(Utils.degreesToByte(location.getYaw()));
+
+        // Head pitch
+        packetSetter.writeByte(Utils.degreesToByte(headPitch));
+
+        // Object data
+        packetSetter.writeInt(objectData);
+
+        // Velocity
+        packetSetter.writeShort(0);
+        packetSetter.writeShort(0);
+        packetSetter.writeShort(0);
+
+        rawPacket = new PacketPlayOutSpawnEntity(packetSetter);
+    }
+
+
+    @Override
+    Packet<?> getRawPacket() {
+        return rawPacket;
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/SpawnEntityPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/SpawnEntityPacket.java
@@ -2,8 +2,10 @@ package me.theguyhere.villagerdefense.nms.v1_20_r4;
 
 import me.theguyhere.villagerdefense.common.Utils;
 import me.theguyhere.villagerdefense.nms.common.EntityID;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+import net.minecraft.server.MinecraftServer;
 import org.bukkit.Location;
 
 /**
@@ -50,7 +52,7 @@ class SpawnEntityPacket extends VersionNMSPacket {
         packetSetter.writeShort(0);
         packetSetter.writeShort(0);
 
-        rawPacket = new PacketPlayOutSpawnEntity(packetSetter);
+        rawPacket = PacketPlayOutSpawnEntity.a.decode(new RegistryFriendlyByteBuf(packetSetter, MinecraftServer.getServer().bc()));
     }
 
 

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSManager.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSManager.java
@@ -1,0 +1,113 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import me.theguyhere.villagerdefense.common.CommunicationManager;
+import me.theguyhere.villagerdefense.nms.common.EntityID;
+import me.theguyhere.villagerdefense.nms.common.NMSErrors;
+import me.theguyhere.villagerdefense.nms.common.NMSManager;
+import me.theguyhere.villagerdefense.nms.common.PacketListener;
+import me.theguyhere.villagerdefense.nms.common.entities.TextPacketEntity;
+import me.theguyhere.villagerdefense.nms.common.entities.VillagerPacketEntity;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.server.network.PlayerConnection;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.function.Consumer;
+
+/**
+ * Manager class for a specific NMS version.
+ */
+public class VersionNMSManager implements NMSManager {
+    @Override
+    public TextPacketEntity newTextPacketEntity() {
+        return new PacketEntityArmorStand(new EntityID());
+    }
+
+    @Override
+    public VillagerPacketEntity newVillagerPacketEntity() {
+        return new PacketEntityVillager(new EntityID());
+    }
+
+    @Override
+    public String getSpawnParticleName() {
+        return "FLAME";
+    }
+
+    @Override
+    public String getMonsterParticleName() {
+        return "SOUL_FIRE_FLAME";
+    }
+
+    @Override
+    public String getVillagerParticleName() {
+        return "COMPOSTER";
+    }
+
+    @Override
+    public String getBorderParticleName() {
+        return "REDSTONE";
+    }
+
+    @Override
+    public void injectPacketListener(Player player, PacketListener packetListener) {
+        modifyPipeline(player, (ChannelPipeline pipeline) -> {
+            ChannelHandler currentListener = pipeline.get(InboundPacketHandler.HANDLER_NAME);
+
+            // Remove old listener
+            if (currentListener != null) {
+                pipeline.remove(InboundPacketHandler.HANDLER_NAME);
+            }
+
+            // Inject new listener
+            pipeline.addBefore("packet_handler", InboundPacketHandler.HANDLER_NAME,
+                    new InboundPacketHandler(player, packetListener));
+        });
+    }
+
+    @Override
+    public void uninjectPacketListener(Player player) {
+        modifyPipeline(player, (ChannelPipeline pipeline) -> {
+            ChannelHandler currentListener = pipeline.get(InboundPacketHandler.HANDLER_NAME);
+
+            // Remove old listener
+            if (currentListener != null) {
+                pipeline.remove(InboundPacketHandler.HANDLER_NAME);
+            }
+        });
+    }
+
+    /**
+     * This is to ensure that pipeline modification doesn't happen on the main thread, which can cause concurrency
+     * issues.
+     * @param player Player to affect.
+     * @param pipelineModifierTask Consumer function for modifying pipeline.
+     */
+    private void modifyPipeline(Player player, Consumer<ChannelPipeline> pipelineModifierTask) {
+        PlayerConnection playerConnection = ((CraftPlayer) player).getHandle().c;
+        // Connection field lives in ServerCommonPacketListenerImpl, superclass of ServerGamePacketListenerImpl,
+        // so Utils.getFieldValue() won't work here (since it uses getDeclaredField()).
+        NetworkManager networkManager;
+        try {
+            Field field = playerConnection.getClass().getSuperclass().getDeclaredField("c");
+            field.setAccessible(true);
+            networkManager = (NetworkManager) field.get(playerConnection);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+            return;
+        }
+        Channel channel = networkManager.n;
+
+        channel.eventLoop().execute(() -> {
+            try {
+                pipelineModifierTask.accept(channel.pipeline());
+            } catch (Exception e) {
+                CommunicationManager.debugError(NMSErrors.EXCEPTION_MODIFYING_CHANNEL_PIPELINE, 0);
+                e.printStackTrace();
+            }
+        });
+    }
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSManager.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSManager.java
@@ -12,7 +12,7 @@ import me.theguyhere.villagerdefense.nms.common.entities.TextPacketEntity;
 import me.theguyhere.villagerdefense.nms.common.entities.VillagerPacketEntity;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.server.network.PlayerConnection;
-import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 import java.lang.reflect.Field;
@@ -92,7 +92,7 @@ public class VersionNMSManager implements NMSManager {
         // so Utils.getFieldValue() won't work here (since it uses getDeclaredField()).
         NetworkManager networkManager;
         try {
-            Field field = playerConnection.getClass().getSuperclass().getDeclaredField("c");
+            Field field = playerConnection.getClass().getSuperclass().getDeclaredField("e");
             field.setAccessible(true);
             networkManager = (NetworkManager) field.get(playerConnection);
         } catch (NoSuchFieldException | IllegalAccessException e) {

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSPacket.java
@@ -1,0 +1,26 @@
+package me.theguyhere.villagerdefense.nms.v1_20_r4;
+
+import me.theguyhere.villagerdefense.nms.common.PacketGroup;
+import net.minecraft.network.protocol.Packet;
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+/**
+ * Abstract packet class for specific NMS version.
+ *
+ * This abstract class was borrowed from filoghost.
+ */
+abstract class VersionNMSPacket implements PacketGroup {
+
+    /**
+     * Send packet group to player.
+     *
+     * @param player Recipient.
+     */
+    @Override
+    public void sendTo(Player player) {
+        ((CraftPlayer) player).getHandle().c.b(getRawPacket());
+    }
+
+    abstract Packet<?> getRawPacket();
+}

--- a/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSPacket.java
+++ b/nms/v1_20_r4/src/main/java/me/theguyhere/villagerdefense/nms/v1_20_r4/VersionNMSPacket.java
@@ -2,7 +2,7 @@ package me.theguyhere.villagerdefense.nms.v1_20_r4;
 
 import me.theguyhere.villagerdefense.nms.common.PacketGroup;
 import net.minecraft.network.protocol.Packet;
-import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_20_R4.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
 /**

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -30,6 +30,11 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>VillagerDefense-nms-v1_20_r4</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>VillagerDefense-nms-v1_20_r3</artifactId>
         </dependency>
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/tools/NMSVersion.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/tools/NMSVersion.java
@@ -16,7 +16,8 @@ public enum NMSVersion {
     v1_19_R3(new me.theguyhere.villagerdefense.nms.v1_19_r3.VersionNMSManager()),
     v1_20_R1(new me.theguyhere.villagerdefense.nms.v1_20_r1.VersionNMSManager()),
     v1_20_R2(new me.theguyhere.villagerdefense.nms.v1_20_r2.VersionNMSManager()),
-    v1_20_R3(new me.theguyhere.villagerdefense.nms.v1_20_r3.VersionNMSManager());
+    v1_20_R3(new me.theguyhere.villagerdefense.nms.v1_20_r3.VersionNMSManager()),
+    v1_20_R4(new me.theguyhere.villagerdefense.nms.v1_20_r4.VersionNMSManager());
 
     private static final NMSVersion CURRENT_VERSION = extractCurrentVersion();
 
@@ -69,6 +70,17 @@ public enum NMSVersion {
      * @return the NMS package part or null if not found.
      */
     private static String extractNMSVersion() {
+        String[] versionParts = Bukkit.getServer().getBukkitVersion().split("-")[0].split("\\.");
+        int majorVer = Integer.parseInt(versionParts[1]);
+        int minorVer = 0;
+        if (versionParts.length > 2) {
+            minorVer = Integer.parseInt(versionParts[2]);
+        }
+        // If we're on 1.20.5 or higher, the server package may not be relocated on Paper
+        if (majorVer == 20 && minorVer >= 5) {
+            return "v1_20_R4";
+        }
+
         Matcher matcher = Pattern.compile("v\\d+_\\d+_R\\d+").matcher(Bukkit.getServer().getClass().getPackage().getName());
         if (matcher.find()) {
             return matcher.group();

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,12 @@
             </dependency>
 
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>VillagerDefense-nms-v1_20_r4</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.spigotmc</groupId>
                 <artifactId>spigot-api</artifactId>
                 <version>${spigot-api.version}</version>


### PR DESCRIPTION
This PR adds support for 1.20.5/6. The code to check the NMS version has been slightly changed since Paper removed the CraftBukkit package relocation (e.g. `org.bukkit.craftbukkit.v1_20_R3`) as of 1.20.5 (more details [here](https://forums.papermc.io/threads/1106/)).

I tested briefly and I was able to see and interact with the villagers and holograms in the lobby.