### PR TITLE
Fix enchantment menu on 1.21.1+

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/common/pom.xml
+++ b/nms/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/pom.xml
+++ b/nms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_16_r3/pom.xml
+++ b/nms/v1_16_r3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_17_r1/pom.xml
+++ b/nms/v1_17_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_18_r1/pom.xml
+++ b/nms/v1_18_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_18_r2/pom.xml
+++ b/nms/v1_18_r2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_19_r1/pom.xml
+++ b/nms/v1_19_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_19_r2/pom.xml
+++ b/nms/v1_19_r2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_19_r3/pom.xml
+++ b/nms/v1_19_r3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_20_r1/pom.xml
+++ b/nms/v1_20_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_20_r2/pom.xml
+++ b/nms/v1_20_r2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_20_r3/pom.xml
+++ b/nms/v1_20_r3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_20_r4/pom.xml
+++ b/nms/v1_20_r4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/nms/v1_21_r1/pom.xml
+++ b/nms/v1_21_r1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-nms</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>VillagerDefense-parent</artifactId>
         <groupId>me.theguyhere</groupId>
-        <version>1.2.11</version>
+        <version>1.2.12</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/inventories/Inventories.java
+++ b/plugin/src/main/java/me/theguyhere/villagerdefense/plugin/inventories/Inventories.java
@@ -1410,7 +1410,7 @@ public class Inventories {
 	// Generate the shop menu
 	public static Inventory createShopMenu(int level, Arena arena) {
 		String disabled = " &4&l[" + LanguageManager.messages.disabled + "]";
-		
+
 		// Create inventory
 		Inventory inv = Bukkit.createInventory(
 				new InventoryMeta(InventoryID.SHOP_MENU, InventoryType.MENU),
@@ -1618,7 +1618,7 @@ public class Inventories {
 		inv.setItem(3, ItemManager.createItem(Material.NETHERITE_AXE,
 				CommunicationManager.format("&a&lIncrease Sharpness"),
 				ItemManager.BUTTON_FLAGS, null, CommunicationManager.format("&2Costs 8 XP Levels")));
-		inv.setItem(4, ItemManager.createItem(Material.FIRE,
+		inv.setItem(4, ItemManager.createItem(Material.FIRE_CHARGE,
 				CommunicationManager.format("&a&lIncrease Fire Aspect"),
 				CommunicationManager.format("&2Costs 10 XP Levels")));
 

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: me.theguyhere.villagerdefense.plugin.Main
 name: VillagerDefense
-version: 1.2.10
+version: 1.2.12
 author: Theguyhere
 api-version: 1.16
 softdepend: [WorldGuard, WorldEdit, Multiverse-core, PlaceholderAPI]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>me.theguyhere</groupId>
     <artifactId>VillagerDefense-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.11</version>
+    <version>1.2.12</version>
     <name>VillagerDefense Parent</name>
 
     <modules>


### PR DESCRIPTION
As of Paper 1.21.1, it seems you can no longer create ItemStacks of things that aren't items, such as the material `FIRE`. Previously, the display item for the Fire Aspect enchantment was the `FIRE` item, which only prevented it from displaying on versions below 1.21, but now, construction of such an ItemStack throws an exception and causes the enchantment menu to not open at all.

This PR fixes it by using `FIRE_CHARGE` as the display item instead.